### PR TITLE
Revert "Reorder z-index declarations"

### DIFF
--- a/packages/component-button/src/styles.less
+++ b/packages/component-button/src/styles.less
@@ -49,20 +49,19 @@
 
 	.skeoh-ui-button {
 		position: relative;
+		z-index: 1;
+
+		&:not(:disabled):not([disabled]):not(.disabled) {
+			&:hover,
+			&.hover {
+				z-index: 2;
+			}
+		}
 
 		&:disabled,
 		&[disabled],
 		&.disabled {
 			z-index: 0;
-		}
-
-		&:not(:disabled):not([disabled]):not(.disabled) {
-			z-index: 1;
-
-			&:hover,
-			&.hover {
-				z-index: 2;
-			}
 		}
 
 		&:focus,


### PR DESCRIPTION
This reverts commit 2772f29230f5ef67585ad8fef571be8698ac18a8 (#2).

This commit caused focused buttons to appear behind other buttons in a button group.