### PR TITLE
Remove `/src` from import paths

### DIFF
--- a/packages/component-button/src/group.tsx
+++ b/packages/component-button/src/group.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
-import { FlexContainer, FlexItem } from '@skeoh-ui/component-flex/src';
-import { Fill } from '@skeoh-ui/component-fill/src';
+import { FlexContainer, FlexItem } from '@skeoh-ui/component-flex';
+import { Fill } from '@skeoh-ui/component-fill';
 
 export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	vertical?: boolean;

--- a/packages/guide/src/components/Demo.tsx
+++ b/packages/guide/src/components/Demo.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as CodeMirror from 'react-codemirror';
-import { Submit } from '@skeoh-ui/component-button/src';
-import { FillHorizontal } from '@skeoh-ui/component-fill/src';
+import { Submit } from '@skeoh-ui/component-button';
+import { FillHorizontal } from '@skeoh-ui/component-fill';
 import * as ts from 'typescript';
 import bootstrap from '../safe-imports';
 

--- a/packages/guide/src/safe-imports.ts
+++ b/packages/guide/src/safe-imports.ts
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
-import * as ComponentButton from '@skeoh-ui/component-button/src';
-import * as ComponentFill from '@skeoh-ui/component-fill/src';
-import * as ComponentFlex from '@skeoh-ui/component-flex/src';
-import * as ComponentInput from '@skeoh-ui/component-input/src';
+import * as ComponentButton from '@skeoh-ui/component-button';
+import * as ComponentFill from '@skeoh-ui/component-fill';
+import * as ComponentFlex from '@skeoh-ui/component-flex';
+import * as ComponentInput from '@skeoh-ui/component-input';
 
 const xrequire = (moduleName: string) => {
 	switch (moduleName) {


### PR DESCRIPTION
This was added to assist VSCode in finding typings for each module without needing to rebuild dependencies. As it turns out, Code is smart enough to pull typings from the source without the need to rebuild.

By updating these paths we can run each module as 100% JavaScript when built -- TypeScript is just used to compile, not to run.