### PR TITLE
Fill children without cloning them

### DIFF
--- a/packages/component-fill/features/fill.feature
+++ b/packages/component-fill/features/fill.feature
@@ -6,7 +6,3 @@ Feature: Horizontal and vertical fill component
 		Then the component should have the class "skeoh-ui-fill"
 		And the component should have the class "helloworld"
 		And the component should have the class "foobar"
-
-	Scenario: Child component has the right class
-		Given a fill component with a child
-		Then the child should have the class "skeoh-ui-fill"

--- a/packages/component-fill/features/horizontal.feature
+++ b/packages/component-fill/features/horizontal.feature
@@ -6,7 +6,3 @@ Feature: Horizontal fill component
 		Then the component should have the class "skeoh-ui-fill-horizontal"
 		And the component should have the class "helloworld"
 		And the component should have the class "foobar"
-
-	Scenario: Child component has the right class
-		Given a horizontal fill component with a child
-		Then the child should have the class "skeoh-ui-fill-horizontal"

--- a/packages/component-fill/features/steps/fill.js
+++ b/packages/component-fill/features/steps/fill.js
@@ -21,21 +21,4 @@ defineSupportCode(function (support) {
 				throw new Error('Unrecognized type: ' + type);
 		}
 	});
-
-	support.Given(/^a (fill|horizontal fill|vertical fill) component with a child$/, function (type) {
-		const child = React.createElement('div');
-		switch (type) {
-			case 'horizontal fill':
-				this.wrapper = shallow(React.createElement(Horizontal, {}, child));
-				break;
-			case 'vertical fill':
-				this.wrapper = shallow(React.createElement(Vertical, {}, child));
-				break;
-			case 'fill':
-				this.wrapper = shallow(React.createElement(Fill, {}, child));
-				break;
-			default:
-				throw new Error('Unrecognized type: ' + type);
-		}
-	});
 });

--- a/packages/component-fill/features/vertical.feature
+++ b/packages/component-fill/features/vertical.feature
@@ -6,7 +6,3 @@ Feature: Vertical fill component
 		Then the component should have the class "skeoh-ui-fill-vertical"
 		And the component should have the class "helloworld"
 		And the component should have the class "foobar"
-
-	Scenario: Child component has the right class
-		Given a vertical fill component with a child
-		Then the child should have the class "skeoh-ui-fill-vertical"

--- a/packages/component-fill/src/fill.tsx
+++ b/packages/component-fill/src/fill.tsx
@@ -5,20 +5,8 @@ export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 
 }
 
-const wrapChild = (child: React.ReactElement<any>) => (
-	React.cloneElement(
-		child,
-		{
-			...child.props,
-			className: classNames('skeoh-ui-fill', child.props.className),
-		},
-	)
-);
-
-const Fill = ({ className, children, ...props }: IProps) => (
-	<div className={ classNames('skeoh-ui-fill', className) } { ...props }>
-		{ React.Children.map(children, wrapChild) }
-	</div>
+const Fill = ({ className, ...props }: IProps) => (
+	<div className={ classNames('skeoh-ui-fill', className) } { ...props } />
 );
 
 export default Fill;

--- a/packages/component-fill/src/horizontal.tsx
+++ b/packages/component-fill/src/horizontal.tsx
@@ -5,20 +5,8 @@ export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 
 }
 
-const wrapChild = (child: React.ReactElement<any>) => (
-	React.cloneElement(
-		child,
-		{
-			...child.props,
-			className: classNames('skeoh-ui-fill-horizontal', child.props.className),
-		},
-	)
-);
-
-const FillHorizontal = ({ className, children, ...props }: IProps) => (
-	<div className={ classNames('skeoh-ui-fill-horizontal', className) } { ...props }>
-		{ React.Children.map(children, wrapChild) }
-	</div>
+const FillHorizontal = ({ className, ...props }: IProps) => (
+	<div className={ classNames('skeoh-ui-fill-horizontal', className) } { ...props } />
 );
 
 export default FillHorizontal;

--- a/packages/component-fill/src/styles.less
+++ b/packages/component-fill/src/styles.less
@@ -1,11 +1,15 @@
 @import "../node_modules/@skeoh-ui/common-styles/src/styles";
 
 .skeoh-ui-fill,
-.skeoh-ui-fill-horizontal {
+.skeoh-ui-fill > *,
+.skeoh-ui-fill-horizontal,
+.skeoh-ui-fill-horizontal > * {
 	width: 100%;
 }
 
 .skeoh-ui-fill,
-.skeoh-ui-fill-vertical {
+.skeoh-ui-fill > *,
+.skeoh-ui-fill-vertical,
+.skeoh-ui-fill-vertical > * {
 	height: 100%;
 }

--- a/packages/component-fill/src/vertical.tsx
+++ b/packages/component-fill/src/vertical.tsx
@@ -5,20 +5,8 @@ export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 
 }
 
-const wrapChild = (child: React.ReactElement<any>) => (
-	React.cloneElement(
-		child,
-		{
-			...child.props,
-			className: classNames('skeoh-ui-fill-vertical', child.props.className),
-		},
-	)
-);
-
-const FillVertical = ({ className, children, ...props }: IProps) => (
-	<div className={ classNames('skeoh-ui-fill-vertical', className) } { ...props }>
-		{ React.Children.map(children, wrapChild) }
-	</div>
+const FillVertical = ({ className, ...props }: IProps) => (
+	<div className={ classNames('skeoh-ui-fill-vertical', className) } { ...props } />
 );
 
 export default FillVertical;


### PR DESCRIPTION
* Uses CSS to target children of the `skeoh-ui-fill-horizontal`, `skeoh-ui-fill-vertical` and `skeoh-ui-fill` classes
* Avoids the need to clone children to add a new class name to each
* Allows children to fill even if they ignore props given to them (like `className`)