### PR TITLE
Test that submit buttons have default text

### DIFF
--- a/packages/component-button/features/submit.feature
+++ b/packages/component-button/features/submit.feature
@@ -12,3 +12,8 @@ Feature: Submit button component
 	Scenario: Button has the right text by default
 		Given a submit button component
 		Then the component should have the text "Submit"
+
+	Scenario: Default text can be overridden
+		Given a submit button component
+		When the component has the text "Apply"
+		Then the component should have the text "Apply"

--- a/packages/component-button/features/submit.feature
+++ b/packages/component-button/features/submit.feature
@@ -8,3 +8,7 @@ Feature: Submit button component
 		Given a submit button component
 		When the prop "type" is set to "button"
 		Then the component should have the prop "type" set to "button"
+
+	Scenario: Button has the right text by default
+		Given a submit button component
+		Then the component should have the text "Submit"

--- a/steps/wrapper.js
+++ b/steps/wrapper.js
@@ -15,6 +15,10 @@ defineSupportCode(function (support) {
 		this.wrapper.setProps(newProps);
 	});
 
+	support.When(/^the component has the text "([^"]*?)"$/, function (text) {
+		this.wrapper.setProps({ children: text });
+	});
+
 	support.Then(/^the component should have the class "([^"]*?)"$/, function (className) {
 		assert(this.wrapper.hasClass(className));
 	});

--- a/steps/wrapper.js
+++ b/steps/wrapper.js
@@ -30,4 +30,8 @@ defineSupportCode(function (support) {
 	support.Then(/^the component should have the style "([^"]*?)" set to "([^"]*?)"$/, function (styleName, value) {
 		assert.equal(this.wrapper.prop('style')[styleName], value);
 	});
+
+	support.Then(/^the component should have the text "([^"]*?)"$/, function (value) {
+		assert.equal(this.wrapper.children().text(), value);
+	});
 });


### PR DESCRIPTION
Simply asserts that a submit button component with no children will display the default text of "Submit".