### PR TITLE
Clean up some LESS imports

### DIFF
--- a/packages/common-styles/src/styles.less
+++ b/packages/common-styles/src/styles.less
@@ -1,4 +1,4 @@
-@import "~normalize.css/normalize.css";
+@import "~normalize.css";
 
 @import "colors";
 @import "animations";

--- a/packages/guide/src/styles/index.less
+++ b/packages/guide/src/styles/index.less
@@ -1,4 +1,4 @@
-@import (inline) "../../../../node_modules/codemirror/lib/codemirror.css";
+@import "../../../../node_modules/codemirror/lib/codemirror.css";
 
 @import "../../node_modules/@skeoh-ui/component-button/src/styles";
 @import "../../node_modules/@skeoh-ui/component-input/src/styles";


### PR DESCRIPTION
* Refers to `normalize.css` as only `~normalize.css` instead of `~normalize.css/normalize.css`
* Removes `(inline)` import directive from CodeMirror CSS import -- allows LESS to process imported styles