### PR TITLE
Rename `IProps` -> `Props`

### DIFF
--- a/packages/component-button/src/button.tsx
+++ b/packages/component-button/src/button.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
 
-export interface IProps extends React.HTMLAttributes<HTMLInputElement> {
+export interface Props extends React.HTMLAttributes<HTMLInputElement> {
 
 }
 
-const Button = (props: IProps) => (
+const Button = (props: Props) => (
 	<button
 		type="button"
 		{ ...props }

--- a/packages/component-button/src/group.tsx
+++ b/packages/component-button/src/group.tsx
@@ -3,7 +3,7 @@ import * as classNames from 'classnames';
 import { FlexContainer, FlexItem } from '@skeoh-ui/component-flex';
 import { Fill } from '@skeoh-ui/component-fill';
 
-export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface Props extends React.HTMLAttributes<HTMLDivElement> {
 	vertical?: boolean;
 }
 
@@ -13,7 +13,7 @@ const flexItem = (child: React.ReactNode) => (
 	</FlexItem>
 );
 
-const ButtonGroup = ({ vertical, className, children, ...props }: IProps) => (
+const ButtonGroup = ({ vertical, className, children, ...props }: Props) => (
 	<div
 		{ ...props }
 		className={ classNames({

--- a/packages/component-button/src/submit.tsx
+++ b/packages/component-button/src/submit.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
-import Button, { IProps as IButtonProps } from './button';
+import Button, { Props as ButtonProps } from './button';
 
-export interface IProps extends IButtonProps {
+export interface Props extends ButtonProps {
 
 }
 
-const Submit = ({ children, className, ...props }: IProps) => (
+const Submit = ({ children, className, ...props }: Props) => (
 	<Button
 		type="submit"
 		className={ classNames('skeoh-ui-button-submit', className) }

--- a/packages/component-fill/src/fill.tsx
+++ b/packages/component-fill/src/fill.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
 
-export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface Props extends React.HTMLAttributes<HTMLDivElement> {
 
 }
 
-const Fill = ({ className, ...props }: IProps) => (
+const Fill = ({ className, ...props }: Props) => (
 	<div className={ classNames('skeoh-ui-fill', className) } { ...props } />
 );
 

--- a/packages/component-fill/src/horizontal.tsx
+++ b/packages/component-fill/src/horizontal.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
 
-export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface Props extends React.HTMLAttributes<HTMLDivElement> {
 
 }
 
-const FillHorizontal = ({ className, ...props }: IProps) => (
+const FillHorizontal = ({ className, ...props }: Props) => (
 	<div className={ classNames('skeoh-ui-fill-horizontal', className) } { ...props } />
 );
 

--- a/packages/component-fill/src/vertical.tsx
+++ b/packages/component-fill/src/vertical.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
 
-export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface Props extends React.HTMLAttributes<HTMLDivElement> {
 
 }
 
-const FillVertical = ({ className, ...props }: IProps) => (
+const FillVertical = ({ className, ...props }: Props) => (
 	<div className={ classNames('skeoh-ui-fill-vertical', className) } { ...props } />
 );
 

--- a/packages/component-flex/src/container.tsx
+++ b/packages/component-flex/src/container.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
 
-export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface Props extends React.HTMLAttributes<HTMLDivElement> {
 	row?: boolean;
 	rowReverse?: boolean;
 	column?: boolean;
 	columnReverse?: boolean;
 }
 
-const getFlexDirection = (props: IProps) => {
+const getFlexDirection = (props: Props) => {
 	if (props.row) {
 		return 'row';
 	} else if (props.rowReverse) {
@@ -30,7 +30,7 @@ const FlexContainer = ({
 	column,
 	columnReverse,
 	...props,
-}: IProps) => (
+}: Props) => (
 	<div
 		{ ...props }
 		className={ classNames('skeoh-ui-flex-container', className) }

--- a/packages/component-flex/src/item.tsx
+++ b/packages/component-flex/src/item.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
 
-export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface Props extends React.HTMLAttributes<HTMLDivElement> {
 	grow: number;
 }
 
-const FlexItem = ({ className, style, grow, ...props }: IProps) => (
+const FlexItem = ({ className, style, grow, ...props }: Props) => (
 	<div
 		{ ...props }
 		className={ classNames('skeoh-ui-flex-item', className) }

--- a/packages/component-input/src/input.tsx
+++ b/packages/component-input/src/input.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
 
-export interface IProps extends React.HTMLAttributes<HTMLInputElement> {
+export interface Props extends React.HTMLAttributes<HTMLInputElement> {
 
 }
 
-const Input = ({ className, ...props }: IProps) => (
+const Input = ({ className, ...props }: Props) => (
 	<input
 		type="text"
 		{ ...props }

--- a/packages/component-input/src/number.tsx
+++ b/packages/component-input/src/number.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
-import Input, { IProps as IInputProps } from './input';
+import Input, { Props as InputProps } from './input';
 
-export interface IProps extends IInputProps {
+export interface Props extends InputProps {
 	hideSpinner?: boolean;
 }
 
-const NumberInput = ({ hideSpinner, className, ...props }: IProps) => (
+const NumberInput = ({ hideSpinner, className, ...props }: Props) => (
 	<Input
 		type="number"
 		{ ...props }


### PR DESCRIPTION
Removes the `I` prefix from all props interface declarations. Props can be defined as a non-interface data type so it doesn't make sense to always name them `IProps`.