### PR TITLE
Correctly inherit button component props from button element

### DIFF
--- a/packages/component-button/src/button.tsx
+++ b/packages/component-button/src/button.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
 
-export interface Props extends React.HTMLAttributes<HTMLInputElement> {
+export interface Props extends React.HTMLAttributes<HTMLButtonElement> {
 
 }
 


### PR DESCRIPTION
The base button component previously inherited incorrectly from `HTMLInputElement`. It now correctly inherits from `HTMLButtonElement`.

I probably copied and pasted the base input component when I made the button.